### PR TITLE
Issue opemam#58 Unexpected screen is displayed when the authentication chain fails

### DIFF
--- a/forgerock-ui-user/src/main/js/config/routes/UserRoutesConfig.js
+++ b/forgerock-ui-user/src/main/js/config/routes/UserRoutesConfig.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions copyright 2019 Open Source Solution Technology Corporation
  */
 
 define([
@@ -23,28 +24,28 @@ define([
         "profile": {
             view: "UserProfileView",
             role: "ui-self-service-user",
-            url: /profile\/(.*)/,
+            url: /^profile\/(.*)/,
             pattern: "profile/?",
             defaults: ["details"],
             navGroup: "user"
         },
         "forgotUsername": {
             view: "ForgotUsernameView",
-            url: /forgotUsername(\/[^\&]*)(\&.+)?/,
+            url: /^forgotUsername(\/[^\&]*)(\&.+)?/,
             pattern: "forgotUsername??",
             argumentNames: ["realm", "additionalParameters"],
             defaults: ["/", ""]
         },
         "passwordReset": {
             view: "PasswordResetView",
-            url: /passwordReset(\/[^\&]*)(\&.+)?/,
+            url: /^passwordReset(\/[^\&]*)(\&.+)?/,
             pattern: "passwordReset??",
             argumentNames: ["realm", "additionalParameters"],
             defaults: ["/", ""]
         },
         "selfRegistration": {
             view: "RegisterView",
-            url: /register(\/[^\&]*)(\&.+)?/,
+            url: /^register(\/[^\&]*)(\&.+)?/,
             pattern: "register??",
             argumentNames: ["realm", "additionalParameters"],
             defaults: ["/",""]


### PR DESCRIPTION
## Analysis

XUI displays each screen according to the URL pattern of `RoutesConfig`. They are defined as regular expression in some settings, but don't consider the beginning of the string. As a result, it may match the fragment's goto parameter. After that, XUI displays an unexpected screen.

## Solution

Fix routing rules

## Testing

* Try openam-jp/openam#58 "Steps to reproduce" with openam-jp/openam#149