### PR TITLE
Issue forgerock-bom#2 Promote dependency management by BOM

### DIFF
--- a/forgerock-ui-external-libs/pom.xml
+++ b/forgerock-ui-external-libs/pom.xml
@@ -14,6 +14,8 @@
   ~
   ~ Copyright 2019 Open Source Solution Technology Corporation
   ~
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+  ~
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -184,7 +186,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://arshaw.com/xdate/downloads/0.8/xdate.js</url>
+                            <url>https://raw.githubusercontent.com/arshaw/xdate/v0.8/src/xdate.js</url>
                             <outputDirectory>${project.basedir}/target/external</outputDirectory>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Analysis
openam-jp/forgerock-bom#2

Since last year, security alerts have been sent from GitHub about Maven dependencies.
After forking this BOM project, I noticed alerts fixed in OpenAM were also occurring.
It's annoying to fix the same alert across multiple projects.

## Solution
- Move dependencies defined in multiple projects to BOM
- Use BOM in each project
- Do not overwrite the dependency version defined in BOM in each project
- If multiple versions of the same library are used, unify them to the new version

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-bom
- forgerock-build-tools
- forgerock--i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- opendj-sdk
- opendj
- openam

## Regression testing
There is no change in test results by test framework.
