### PR TITLE
Issue #6 xdate.js not found

### DIFF
--- a/forgerock-ui-external-libs/pom.xml
+++ b/forgerock-ui-external-libs/pom.xml
@@ -14,6 +14,8 @@
   ~
   ~ Copyright 2019 Open Source Solution Technology Corporation
   ~
+  ~ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
+  ~
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -184,7 +186,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://arshaw.com/xdate/downloads/0.8/xdate.js</url>
+                            <url>https://raw.githubusercontent.com/arshaw/xdate/v0.8/src/xdate.js</url>
                             <outputDirectory>${project.basedir}/target/external</outputDirectory>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Analysis
openam-jp/forgerock-ui#6

After fix of openam-jp/openam#36, the necessary JavaScripts are downloaded from CDN, GitHub, etc.
XDate.js cannot be obtained from the URL described in the current Master and build fails.
It seems that we can no longer download xdate.js.

## Solution
Changed URL to download XDate.js from GitHub.

- Current (404 Not Found): https://arshaw.com/xdate/downloads/0.8/xdate.js
- After change: https://raw.githubusercontent.com/arshaw/xdate/v0.8/src/xdate.js
