### PR TITLE
Issue openam#206 Add options for Cookie SameSite attribute

### DIFF
--- a/forgerock-ui-commons/src/main/js/org/forgerock/commons/ui/common/util/CookieHelper.js
+++ b/forgerock-ui-commons/src/main/js/org/forgerock/commons/ui/common/util/CookieHelper.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions copyright 2020 Open Source Solution Technology Corporation
  */
 
 define([
@@ -31,22 +32,25 @@ define([
      * @param {String} [path] - cookie path.
      * @param {String|String[]} [domain] - cookie domain(s).
      * @param {Boolean} [secure] - is cookie secure.
+     * @param {String} [samesite] - cookie samesite.
      * @returns {String} created cookie.
      */
-    obj.createCookie = function (name, value, expirationDate, path, domain, secure) {
+    obj.createCookie = function (name, value, expirationDate, path, domain, secure, samesite) {
         var expirationDatePart,
             nameValuePart,
             pathPart,
             domainPart,
-            securePart;
+            securePart,
+            samesitePart;
 
         expirationDatePart = expirationDate ? ";expires=" + expirationDate.toGMTString() : "";
         nameValuePart = name + "=" + value;
         pathPart = path ? ";path=" + path : "";
         domainPart = domain ? ";domain=" + domain : "";
         securePart = secure ? ";secure" : "";
+        samesitePart = samesite ? "; SameSite=" + samesite : "";
 
-        return nameValuePart + expirationDatePart + pathPart + domainPart + securePart;
+        return nameValuePart + expirationDatePart + pathPart + domainPart + securePart + samesitePart;
     };
 
     /**
@@ -57,17 +61,18 @@ define([
      * @param {String} [path] - cookie path.
      * @param {String|String[]} [domain] - cookie domain(s). Use empty array for creating host-only cookies.
      * @param {Boolean} [secure] - is cookie secure.
+     * @param {String} [samesite] - cookie samesite.
      */
-    obj.setCookie = function (name, value, expirationDate, path, domains, secure) {
+    obj.setCookie = function (name, value, expirationDate, path, domains, secure, samesite) {
         if (!_.isArray(domains)) {
             domains = [domains];
         }
 
         if (domains.length === 0) {
-            document.cookie = obj.createCookie(name, value, expirationDate, path, undefined, secure);
+            document.cookie = obj.createCookie(name, value, expirationDate, path, undefined, secure, samesite);
         } else {
             _.each(domains, function(domain) {
-                document.cookie = obj.createCookie(name, value, expirationDate, path, domain, secure);
+                document.cookie = obj.createCookie(name, value, expirationDate, path, domain, secure, samesite);
             });
         }
     };


### PR DESCRIPTION
## Analysis

Chrome treats cookies that have no declared SameSite value as SameSite=Lax cookies.
As a result, OpenAM has some troubles (See openam-jp/openam#206).

If XUI is enabled, OpenAM set cookies not only on the server side but also on the client side. 
Therefore, this project also needs to be changed for SameSite.

## Solution

Add a parameter to the method that creates the cookie.

## Testing

Test with openam-jp/openam#207
