### PR TITLE
Issue openam#255 styles-admin.less fails to compile because codemirror.css cannot be found

### DIFF
--- a/forgerock-ui-external-libs/pom.xml
+++ b/forgerock-ui-external-libs/pom.xml
@@ -397,9 +397,10 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/codemirror/CodeMirror/archive/4.10.0.zip</url>
+                            <url>https://codemirror.net/5/codemirror-4.10.zip</url>
                             <outputDirectory>${project.basedir}/target/external</outputDirectory>
-                            <outputFileName>CodeMirror-4.10.0.zip</outputFileName>
+                            <outputFileName>codemirror-4.10.zip</outputFileName>
+                            <sha1>bf0997d937c3a3a58387ae0b450edabb5a784edf</sha1>
                         </configuration>
                     </execution>
                 </executions>
@@ -949,10 +950,10 @@
                             <goal>install-file</goal>
                         </goals>
                         <configuration>
-                            <file>${basedir}/target/external/CodeMirror-4.10.0.zip</file>
+                            <file>${basedir}/target/external/codemirror-4.10.zip</file>
                             <groupId>jp.openam.commons.ui.libs</groupId>
-                            <artifactId>CodeMirror</artifactId>
-                            <version>4.10.0</version>
+                            <artifactId>codemirror5</artifactId>
+                            <version>4.10</version>
                             <packaging>zip</packaging>
                             <generatePom>true</generatePom>
                         </configuration>

--- a/forgerock-ui-mock/pom.xml
+++ b/forgerock-ui-mock/pom.xml
@@ -22,7 +22,7 @@
   ~ your own identifying information:
   ~ "Portions Copyrighted [year] [name of copyright owner]"
   ~
-  ~ Portions Copyrighted 2019-2020 Open Source Solution Technology Corporation
+  ~ Portions Copyrighted 2019-2022 OSSTech Corporation
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -166,7 +166,7 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>jp.openam.commons.ui.libs</groupId>
-                                    <artifactId>CodeMirror</artifactId>
+                                    <artifactId>codemirror5</artifactId>
                                     <type>zip</type>
                                 </artifactItem>
                             </artifactItems>
@@ -188,8 +188,8 @@
 
         <dependency>
             <groupId>jp.openam.commons.ui.libs</groupId>
-            <artifactId>CodeMirror</artifactId>
-            <version>4.10.0</version>
+            <artifactId>codemirror5</artifactId>
+            <version>4.10</version>
             <type>zip</type>
         </dependency>
 


### PR DESCRIPTION
## Analysis

`forgerock-ui-external-libs` has a process to download `CodeMirror` and install it in the Maven local repository.
So the cause is that the downloaded file has changed.

## Solution

`forgerock-ui-external-libs` installs the new `CodeMirror` archive as a new artifact on Maven.
Then the build process of OpenAM will use the new artifacts.

## Testing

I have confirmed that the OpenAM build is successful with openam-jp/openam#256.