### PR TITLE
Issue openam#423 When the proxy server returns error HTML during login, no error message is displayed

### DIFF
--- a/forgerock-ui-commons/src/main/js/org/forgerock/commons/ui/common/main/ErrorsHandler.js
+++ b/forgerock-ui-commons/src/main/js/org/forgerock/commons/ui/common/main/ErrorsHandler.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions copyright 2026 OSSTech Corporation
  */
 
 define([
@@ -71,6 +72,14 @@ define([
                     )
                 )
                ) {
+                if(handler.event) {
+                    eventManager.sendEvent(handler.event, {handler: handler, error: error});
+                }
+
+                if(handler.message) {
+                    eventManager.sendEvent(constants.EVENT_DISPLAY_MESSAGE_REQUEST, handler.message);
+                }
+            } else if (!error.hasOwnProperty("responseObj")) {
                 if(handler.event) {
                     eventManager.sendEvent(handler.event, {handler: handler, error: error});
                 }


### PR DESCRIPTION
## Solution

Add error handling for HTML responses.

## Testing

Test with openam-jp/openam#424